### PR TITLE
Make version a const string

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,15 +9,14 @@ import (
 	ebiten "github.com/hajimehoshi/ebiten/v2"
 )
 
-var version string
-
 const (
 	exitCodeOK int = iota
 	exitCodeError
 )
 
 const (
-	title = "PokemonRed"
+	version = "Develop"
+	title   = "PokemonRed"
 )
 
 func main() {
@@ -31,7 +30,7 @@ func Run() int {
 	)
 	flag.Parse()
 	if *showVersion {
-		fmt.Println(title+":", getVersion())
+		fmt.Println(title+":", version)
 		return exitCodeOK
 	}
 
@@ -42,11 +41,4 @@ func Run() int {
 		return exitCodeError
 	}
 	return exitCodeOK
-}
-
-func getVersion() string {
-	if version == "" {
-		return "Develop"
-	}
-	return version
 }


### PR DESCRIPTION
By making version a public _const_ string, you eliminate a function call. Defaulting it to "Develop" obtains the same result as the old function call  `getVersion()`.